### PR TITLE
[feat] 게시글 검색 API

### DIFF
--- a/src/main/java/org/harang/server/controller/PostController.java
+++ b/src/main/java/org/harang/server/controller/PostController.java
@@ -10,6 +10,7 @@ import org.harang.server.dto.request.PostRequest;
 import org.harang.server.dto.response.PostResponse;
 import org.harang.server.dto.type.SuccessMessage;
 import org.harang.server.service.PostService;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -33,5 +34,11 @@ public class PostController {
     @GetMapping
     public ApiResponse<List<PostResponse>> getAllPosts() {
         return ApiResponse.success(postService.getAllPosts());
+    }
+
+    @Transactional(readOnly = true)
+    @GetMapping("/search")
+    public ApiResponse<?> getSearchResults(@RequestParam(name = "title") String title) {
+        return ApiResponse.success(postService.getSearchResults(title));
     }
 }

--- a/src/main/java/org/harang/server/repository/PostRepository.java
+++ b/src/main/java/org/harang/server/repository/PostRepository.java
@@ -1,12 +1,16 @@
 package org.harang.server.repository;
 
+import java.util.List;
 import org.harang.server.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.harang.server.dto.type.ErrorMessage;
 import org.harang.server.exception.CustomException;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     default Post findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(() -> new CustomException(ErrorMessage.POST_NOT_FOUND));
     }
+
+    List<Post> findByTitleIsContaining(String title);
 }

--- a/src/main/java/org/harang/server/service/PostService.java
+++ b/src/main/java/org/harang/server/service/PostService.java
@@ -82,6 +82,7 @@ public class PostService {
                 .stream()
                 .map(p -> PostResponse.of(p))
                 .toList();
+    }
 
     @Transactional
     public void deletePost(Long memberId, Long postId) {
@@ -89,6 +90,5 @@ public class PostService {
 
         locationRepository.deleteByPostId(postId);
         postRepository.delete(post);
-
     }
 }

--- a/src/main/java/org/harang/server/service/PostService.java
+++ b/src/main/java/org/harang/server/service/PostService.java
@@ -56,9 +56,9 @@ public class PostService {
                         .build()
         );
 
-        for (String categoryName: request.categoryList()) {
+        for (String categoryName : request.categoryList()) {
             Category category = categoryRepository.findByName(categoryName);
-            if(category != null) {
+            if (category != null) {
                 PostCategory savedPostCategory =
                         PostCategory.builder()
                                 .post(savedPost)
@@ -77,4 +77,10 @@ public class PostService {
                 .collect(Collectors.toList());
     }
 
+    public List<PostResponse> getSearchResults(String title) {
+        return postRepository.findByTitleIsContaining(title)
+                .stream()
+                .map(p -> PostResponse.of(p))
+                .toList();
+    }
 }


### PR DESCRIPTION
- 제목에 검색어가 포함된 게시글만을 반환하는 API
- 동작이 되긴 하는데 연속되게 1초 정도 이내로 api를 호출하면 자꾸 이전 결과를 포함해서 반환한다거나 하는 문제가 생깁니다,,, 일단 올립니당

<img width="282" alt="스크린샷 2024-02-17 오후 6 06 34" src="https://github.com/GDSC-DGU/2024-SolutionChallenge-harang-server/assets/84651773/bf734f19-0c26-4c85-ba97-fcc544931620">
