### PR TITLE
[feat] 추천 게시글 API

### DIFF
--- a/src/main/java/org/harang/server/controller/PostController.java
+++ b/src/main/java/org/harang/server/controller/PostController.java
@@ -8,7 +8,9 @@ import org.harang.server.domain.Post;
 import org.harang.server.dto.common.ApiResponse;
 import org.harang.server.dto.request.PostRequest;
 import org.harang.server.dto.response.PostResponse;
+import org.harang.server.dto.type.ErrorMessage;
 import org.harang.server.dto.type.SuccessMessage;
+import org.harang.server.exception.CustomException;
 import org.harang.server.service.PostService;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
@@ -46,5 +48,10 @@ public class PostController {
     @GetMapping("/search")
     public ApiResponse<?> getSearchResults(@RequestParam(name = "title") String title) {
         return ApiResponse.success(postService.getSearchResults(title));
+    }
+
+    @GetMapping("/recommend")
+    public ApiResponse<?> getRecommendedResults() {
+        return ApiResponse.success(postService.getRecommendedPosts());
     }
 }

--- a/src/main/java/org/harang/server/service/PostService.java
+++ b/src/main/java/org/harang/server/service/PostService.java
@@ -77,6 +77,7 @@ public class PostService {
                 .collect(Collectors.toList());
     }
 
+    // TODO: 이전 호출 결과도 중복되어 반환되는 문제 원인 파악
     public List<PostResponse> getSearchResults(String title) {
         return postRepository.findByTitleIsContaining(title)
                 .stream()

--- a/src/main/java/org/harang/server/service/PostService.java
+++ b/src/main/java/org/harang/server/service/PostService.java
@@ -1,5 +1,7 @@
 package org.harang.server.service;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.harang.server.domain.*;
 import org.harang.server.domain.enums.Status;
@@ -77,7 +79,7 @@ public class PostService {
                 .collect(Collectors.toList());
     }
 
-    // TODO: 이전 호출 결과도 중복되어 반환되는 문제 원인 파악
+    // TODO: 이전 호출 결과도 중복되어 반환되는 문제 원인 파
     public List<PostResponse> getSearchResults(String title) {
         return postRepository.findByTitleIsContaining(title)
                 .stream()
@@ -91,5 +93,22 @@ public class PostService {
 
         locationRepository.deleteByPostId(postId);
         postRepository.delete(post);
+    }
+
+    public List<PostResponse> getRecommendedPosts() {
+        List<Post> posts = postRepository.findAll();
+
+        // 전체 게시글이 3개 미만이면 빈 리스트 반환 (추천 게시글 렌더 X)
+        if (posts.size() < 3) {
+            return new ArrayList<>();
+        }
+
+        Collections.shuffle(posts);
+        List<Post> recommendedPosts = posts.subList(0, 3);
+
+        return recommendedPosts
+                .stream()
+                .map(p -> PostResponse.of(p))
+                .toList();
     }
 }


### PR DESCRIPTION
- 임의로 세 개의 게시글을 골라 반환
- 전체 게시글이 3개 미만이면, 빈 리스트를 반환하며 추천 게시글을 클라이언트에서 렌더링 하지 않는 것으로 간주

성공 예)
<img width="296" alt="스크린샷 2024-03-03 오전 10 08 55" src="https://github.com/GDSC-DGU/2024-SolutionChallenge-harang-server/assets/84651773/32a0a6d2-69bd-41a5-8e19-3e251e463c39">
